### PR TITLE
migrate to Rye

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,5 @@ dmypy.json
 .pdm.toml
 .pdm-python
 pdm.lock
+/requirements.lock
+/requirements-dev.lock

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
     "recommendations": [
-        "ms-python.black-formatter",
         "ryanluker.vscode-coverage-gutters",
         "ms-python.vscode-pylance",
         "ms-python.python",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,7 +8,7 @@
             "source.organizeImports": "explicit"
         },
         // use black formatter
-        "editor.defaultFormatter": "ms-python.black-formatter",
+        "editor.defaultFormatter": "charliermarsh.ruff",
     },
     // enable pytests
     "python.testing.pytestEnabled": true,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,9 @@
 [project]
 name = "optuna-async-helper"
 description = "A Helper Library for Optuna Async Optimization"
+version = "0.3.1"
 authors = [{ name = "杜 世橋 Du Shiqiao", email = "lucidfrontier.45@gmail.com" }]
 license = { text = "MIT" }
-dynamic = ["version"]
 requires-python = ">=3.11"
 dependencies = ["optuna>=3.5.0", "joblib>=1.3.2", "pydantic>=2.6.1"]
 readme = "README.md"
@@ -24,51 +24,66 @@ classifiers = [
 ]
 urls = { "repository" = "https://github.com/lucidfrontier45/optuna-async-helper" }
 
-
 [build-system]
-requires = ["pdm-backend"]
-build-backend = "pdm.backend"
+requires = ["hatchling"]
+build-backend = "hatchling.build"
 
-[tool.pdm.version]
-source = "file"
-path = "src/optuna_async_helper/__init__.py"
+[tool.hatch.metadata]
+allow-direct-references = true
 
-[tool.pdm.dev-dependencies]
-dev = ["black>=24.2.0", "ruff>=0.2.1", "pyright>=1.1.350", "pytest>=8.0.0"]
+[tool.hatch.build.targets.wheel]
+packages = ["src/optuna_async_helper"]
 
-[tool.pdm.scripts]
-black = "black ."
-pyright = "pyright ."
-ruff_lint = "ruff ."
-ruff_fix = "ruff --fix-only ."
-test = "pytest tests"
-format = { composite = ["ruff_fix", "black"] }
-lint = { composite = ["ruff_lint", "pyright"] }
-check = { composite = ["format", "lint", "test"] }
-
-[tool.pytest.ini_options]
-filterwarnings = [
-    "ignore::FutureWarning",
-    "ignore::optuna.exceptions.ExperimentalWarning",
+[tool.rye]
+managed = true
+dev-dependencies = [
+    "pyright>=1.1.358",
+    "pytest-cov>=5.0.0",
+    "uvicorn>=0.29.0",
+    "pytest-xdist>=3.5.0",
 ]
 
-[tool.black]
-target-version = ["py311"]
-# add directory names to exclude from analysis
-extend-exclude = "deps"
+[tool.rye.scripts]
+pyright_lint = "pyright ."
+rye_format = "rye format ."
+rye_lint = "rye lint ."
+rye_fix = "rye lint --fix ."
+test = "pytest tests -n auto --cov=optuna_async_helper --cov-report=term --cov-report=xml"
+format = { chain = ["rye_fix", "rye_format"] }
+lint = { chain = ["rye_lint", "pyright_lint"] }
+check = { chain = ["format", "lint", "test"] }
+
+[tool.pytest.ini_options]
+filterwarnings = ["ignore::FutureWarning"]
 
 [tool.ruff]
 target-version = "py311"
-# add directory names to exclude from analysis
-exclude = ["deps"]
 
 [tool.ruff.lint]
-select = ["E", "F", "W"]
+select = [
+    "E",
+    "F",
+    "W",
+    "I",
+    "B",
+    "RUF",
+    "UP",
+    "N",
+    "SIM",
+    "A",
+    "S",
+    "DTZ",
+    "PIE",
+    "PLE",
+]
+# add directory names to exclude from analysis
+exclude = ["tests/**/*", "deps/**/*"]
 
 [tool.ruff.lint.per-file-ignores]
 "*/__init__.py" = ['F401']
 
 [tool.pyright]
 pythonVersion = "3.11"
+typeCheckingMode = "basic"
 # add directory names to exclude from analysis
 ignore = ["deps"]

--- a/src/optuna_async_helper/__init__.py
+++ b/src/optuna_async_helper/__init__.py
@@ -1,3 +1,4 @@
+import importlib.metadata
 from collections.abc import Callable
 from typing import Literal, ParamSpec, TypeAlias
 
@@ -7,7 +8,7 @@ from optuna.pruners import BasePruner
 from optuna.samplers import BaseSampler, TPESampler
 from pydantic import BaseModel, Field
 
-__version__ = "0.3.0"
+__version__ = importlib.metadata.version("optuna-async-helper")
 
 DomainType: TypeAlias = Literal["int", "float", "categorical", "logint", "logfloat"]
 Numeric: TypeAlias = int | float


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `.gitignore` to include `/requirements.lock` and `/requirements-dev.lock`.
  - Removed the `ms-python.black-formatter` recommendation from `.vscode/extensions.json`.
  - Changed the default Python code formatter in VS Code settings to `charliermarsh.ruff`.
  - Updated `pyproject.toml` with new build system, dependencies, and tool configurations.
  - Dynamically set the version in `src/optuna_async_helper/__init__.py` using `importlib.metadata`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->