### PR TITLE
chore: changed project management tool to uv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ dmypy.json
 pdm.lock
 /requirements.lock
 /requirements-dev.lock
+/uv.lock

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ with tempfile.TemporaryDirectory() as tempdir:
 ```
 
 For more detail, please check `optimize` and `SearchSpec` definitions.
+
+# Development
+
+The project is managed by [uv](https://docs.astral.sh/uv/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,24 +34,25 @@ allow-direct-references = true
 [tool.hatch.build.targets.wheel]
 packages = ["src/optuna_async_helper"]
 
-[tool.rye]
+[tool.uv]
 managed = true
 dev-dependencies = [
     "pyright>=1.1.358",
     "pytest-cov>=5.0.0",
-    "uvicorn>=0.29.0",
     "pytest-xdist>=3.5.0",
+    "taskipy>=1.13.0",
+    "ruff>=0.6.3",
 ]
 
-[tool.rye.scripts]
+[tool.taskipy.tasks]
 pyright_lint = "pyright ."
-rye_format = "rye format ."
-rye_lint = "rye lint ."
-rye_fix = "rye lint --fix ."
+ruff_format = "ruff format ."
+ruff_lint = "ruff check ."
+ruff_fix = "ruff check --fix ."
 test = "pytest tests --cov=optuna_async_helper --cov-report=term --cov-report=xml"
-format = { chain = ["rye_fix", "rye_format"] }
-lint = { chain = ["rye_lint", "pyright_lint"] }
-check = { chain = ["format", "lint", "test"] }
+format = "task ruff_fix && task ruff_format"
+lint = "task ruff_lint && task pyright_lint"
+check = "task format && task lint && task test"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::FutureWarning"]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added a new "Development" section to the README.md to provide guidance on project management using the "uv" tool.
  
- **Chores**
	- Updated the `.gitignore` file to ignore `uv.lock` and retain `requirements-dev.lock`.
	- Restructured the `pyproject.toml` to transition from `rye` to `uv` for dependency management, introducing new tasks for formatting and linting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->